### PR TITLE
SSH Decryption Tracker.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ vgcore.*
 Wireshark.*
 .pytest_cache/
 test/*.log
+
+# Temporary fix.
+build/**

--- a/epan/dissectors/packet-ssh.c
+++ b/epan/dissectors/packet-ssh.c
@@ -106,6 +106,7 @@ struct ssh_flow_data {
     guchar* key1;
     guint key0_len;
     guint key1_len;
+    // TODO This should be guint32 per the specification
     guint64 client_received_seqnr;
     guint64 server_received_seqnr;
     gboolean client_received_none;

--- a/epan/dissectors/packet-ssh.c
+++ b/epan/dissectors/packet-ssh.c
@@ -105,8 +105,6 @@ struct ssh_flow_data {
     guchar* key1;
     guint key0_len;
     guint key1_len;
-    address src;
-    address dest;
     guint64 current_sent_seqnr;
     guint64 current_recv_seqnr;
     int   (*kex_specific_dissector)(guint8 msg_code, tvbuff_t *tvb, packet_info *pinfo, int offset, proto_tree *tree);
@@ -604,8 +602,6 @@ dissect_ssh(tvbuff_t *tvb, packet_info *pinfo, proto_tree *tree, void* data _U_)
         global_data->key1_len = len1;
         global_data->peer_data[CLIENT_PEER_DATA].mac_length=-1;
         global_data->peer_data[SERVER_PEER_DATA].mac_length=-1;
-        global_data->dest = pinfo->dst;
-        global_data->src =  pinfo->src;
 
         g_print("key0 found: %u with len\n", len0);
         g_print("key1 found: %u with len\n", len1);


### PR DESCRIPTION
- Loading the OpenSSH dump:
    - [X] Load dump from hard-coded string.
       - ~Load dump from environment variable~
    - [X] Load dump from UI option
    - [X] Buffer instead of loading the entire file
- Parsing OpenSSH dump:
    - [X] Parse OpenSSH dump for symmetric key dump
    - [ ] Parse OpenSSH dump for encryption algorithm
- Dissecting:
    - [X] Add decryption code (compilable)
    - [X] Calculate the sequence number
    - [X] Decrypt the length of each packet
    - [X] Decrypt the packet contents
    - [ ] Detect rekeying packet, reload keys from dump
    - [X] Display decrypted textual packets in Wireshark
- Algorithmic
    - [ ] Verify the MAC tag